### PR TITLE
[FIX] - Apply API changes for clipboard functions.

### DIFF
--- a/rlcimgui.c
+++ b/rlcimgui.c
@@ -298,12 +298,12 @@ static MouseCursor ImGuiCursorToRaylib(ImGuiMouseCursor cursor)
     };
 }
 
-static const char* GetClipTextCallback(void*) 
+static const char* GetClipTextCallback() 
 {
     return GetClipboardText();
 }
 
-static void SetClipTextCallback(void*, const char* text)
+static void SetClipTextCallback(const char* text)
 {
     SetClipboardText(text);
 }
@@ -466,16 +466,17 @@ static void SetupGlobals(void)
 void SetupBackend(void)
 {
     ImGuiIO* io = igGetIO();
+    ImGuiPlatformIO *pio = igGetPlatformIO();
 	io->BackendPlatformName = "imgui_impl_raylib";
 
 	io->BackendFlags |= ImGuiBackendFlags_HasMouseCursors | ImGuiBackendFlags_HasGamepad | ImGuiBackendFlags_HasSetMousePos;
 
 	io->MousePos = (ImVec2){0, 0};
 
-	io->SetClipboardTextFn = SetClipTextCallback;
-	io->GetClipboardTextFn = GetClipTextCallback;
+	pio->Platform_SetClipboardTextFn = SetClipTextCallback;
+	pio->Platform_GetClipboardTextFn = GetClipTextCallback;
 
-	io->ClipboardUserData = NULL;
+	pio->Platform_ClipboardUserData = NULL;
 }
 
 void rligSetupFontAwesome(void)


### PR DESCRIPTION
I encountered certain errors related to unavailable C syntaxes in MSVC, as well as issues with cimgui API when attempting to set clipboard functions. I'm unsure if I overlooked something, but I've come up with a potential solution.

COMMAND ( MSVC )
`cl /nologo .\main.c rlcimgui.c /Fe.\app.exe /I.\include /link /LIBPATH:.\lib msvcrt.lib raylib.lib cimgui.lib openGL32.lib gdi32.lib winmm.lib kernel32.lib shell32.lib user32.lib /NODEFAULTLIB:msvcrtd /NODEFAULTLIB:libcmt`

OUTPUTS
```
main.c
C:\Users\...\Git\app\app_raylib\hot.h(48): warning C4312: 'type cast': conversion from 'BOOL' to 'void *' of greater size
rlcimgui.c
rlcimgui.c(61): warning C4047: '=': 'ImTextureID' differs in levels of indirection from 'Texture2D *'
rlcimgui.c(301): error C2055: expected formal parameter list, not a type list
rlcimgui.c(306): error C2055: expected formal parameter list, not a type list
rlcimgui.c(475): error C2039: 'SetClipboardTextFn': is not a member of 'ImGuiIO'
C:\Users\...\Git\app\app_raylib\include\cimgui.h(1032): note: see declaration of 'ImGuiIO'
rlcimgui.c(476): error C2039: 'GetClipboardTextFn': is not a member of 'ImGuiIO'
C:\Users\...\Git\app\app_raylib\include\cimgui.h(1032): note: see declaration of 'ImGuiIO'
rlcimgui.c(478): error C2039: 'ClipboardUserData': is not a member of 'ImGuiIO'
C:\Users\...\Git\app\app_raylib\include\cimgui.h(1032): note: see declaration of 'ImGuiIO'
rlcimgui.c(632): warning C4022: 'ImGuiRenderTriangles': pointer mismatch for actual parameter 5
```


